### PR TITLE
Add standard kubelet command

### DIFF
--- a/cmd/kubelet/main.go
+++ b/cmd/kubelet/main.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"time"
+
+	"k8s.io/apiserver/pkg/server"
+	"k8s.io/component-base/logs"
+	"k8s.io/kubernetes/cmd/kubelet/app"
+	_ "k8s.io/kubernetes/pkg/client/metrics/prometheus" // for client metric registration
+	_ "k8s.io/kubernetes/pkg/version/prometheus"        // for version metric registration
+)
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+
+	command := app.NewKubeletCommand(server.SetupSignalHandler())
+	logs.InitLogs()
+	defer logs.FlushLogs()
+
+	if err := command.Execute(); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
The k3s agent overwrites a lot of kubelet options that I want to control to make it easier to connect to our Kubernetes cloud service. I'm separating out kubelet to give us more control over its startup options. 